### PR TITLE
Fix Supabase token refresh handling

### DIFF
--- a/frontend/src/app/Header.tsx
+++ b/frontend/src/app/Header.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useAuth } from '@/hooks/useAuth';
 import { useQueryClient } from '@tanstack/react-query';
+import { signOut as supabaseSignOut } from '@/utils/auth';
 
 const NavLink = ({
   href,
@@ -110,7 +111,7 @@ const Header = () => {
   const queryClient = useQueryClient();
 
   const signout = () => {
-    localStorage.removeItem('token');
+    void supabaseSignOut();
     queryClient.invalidateQueries({ queryKey: ['whoami'] });
     queryClient.invalidateQueries({ queryKey: ['isAdmin'] });
     queryClient.invalidateQueries({ queryKey: ['meetings'] });


### PR DESCRIPTION
## Summary
- synchronize the stored bearer token with Supabase session updates so refreshed access tokens are captured
- add a sign-out helper that clears Supabase session state and reuse it inside the header menu

## Testing
- bun run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69157309802083229f2a1d1fd659bb82)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Synchronizes stored access token with Supabase session changes and centralizes sign-out, updating Header to use it.
> 
> - **Auth**:
>   - Introduces `TOKEN_STORAGE_KEY` and syncs `localStorage` with Supabase session via `getSession` and `onAuthStateChange`.
>   - Updates `whoami` and `signin` to read/write tokens via `TOKEN_STORAGE_KEY`.
>   - Adds `signOut` helper to call `supabase.auth.signOut()` and clear stored token.
> - **UI/Header**:
>   - Replaces manual token removal with `signOut` helper; continues invalidating related React Query caches (`whoami`, `isAdmin`, `meetings`, `latestMeeting`, `posts`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f16f2dd428c32bbb43970b6f0ea5dc80e365c1fc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->