### PR TITLE
Await Supabase sign-out before cache invalidation

### DIFF
--- a/frontend/src/app/Header.tsx
+++ b/frontend/src/app/Header.tsx
@@ -110,13 +110,19 @@ const Header = () => {
 
   const queryClient = useQueryClient();
 
-  const signout = () => {
-    void supabaseSignOut();
-    queryClient.invalidateQueries({ queryKey: ['whoami'] });
-    queryClient.invalidateQueries({ queryKey: ['isAdmin'] });
-    queryClient.invalidateQueries({ queryKey: ['meetings'] });
-    queryClient.invalidateQueries({ queryKey: ['latestMeeting'] });
-    queryClient.invalidateQueries({ queryKey: ['posts'] });
+  const signout = async () => {
+    await supabaseSignOut();
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: ['whoami'] }),
+      queryClient.invalidateQueries({ queryKey: ['isAdmin'] }),
+      queryClient.invalidateQueries({ queryKey: ['meetings'] }),
+      queryClient.invalidateQueries({ queryKey: ['latestMeeting'] }),
+      queryClient.invalidateQueries({ queryKey: ['posts'] }),
+    ]);
+  };
+
+  const handleSignout = () => {
+    void signout();
   };
 
   return (
@@ -154,7 +160,7 @@ const Header = () => {
                   </div>
                 </div>
                 <button
-                  onClick={signout}
+                  onClick={handleSignout}
                   className='flex items-center gap-2 px-4 py-2 text-sm font-medium text-gray-700 hover:text-gray-900'
                 >
                   <LogOut size={18} />
@@ -169,7 +175,7 @@ const Header = () => {
           <MobileMenu
             isOpen={isOpen}
             onToggle={() => setIsOpen(!isOpen)}
-            onSignOut={signout}
+            onSignOut={handleSignout}
           />
         </div>
       </div>


### PR DESCRIPTION
## Summary
- await Supabase sign-out before invalidating React Query caches so refetches happen after tokens are cleared
- wrap header sign-out handler to fire the async sign-out flow without causing type issues

## Testing
- bun run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69157bb47fc08322a4dbf02411e9614d)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make sign-out async, await Supabase logout, then parallelize React Query cache invalidations; use a wrapper handler for Header and MobileMenu triggers.
> 
> - **Frontend – `frontend/src/app/Header.tsx`**:
>   - **Sign-out flow**:
>     - Convert `signout` to `async`, `await` `supabaseSignOut()`, then run `queryClient.invalidateQueries` in `Promise.all` for `whoami`, `isAdmin`, `meetings`, `latestMeeting`, `posts`.
>     - Add `handleSignout` wrapper to invoke async flow; update `onClick` and `MobileMenu` `onSignOut` to use it.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 19528936ae117d74f5ae13c45ebaf90b0c8f6b9c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->